### PR TITLE
Authentication: request macaroons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 canonicalwebteam.flask-base==0.3.3
 Flask-OpenID-Stateless==1.2.6
+requests==2.22.0
+pymacaroons==0.13.0

--- a/webapp/macaroons.py
+++ b/webapp/macaroons.py
@@ -1,0 +1,44 @@
+from openid.extension import Extension as OpenIDExtension
+
+
+class MacaroonRequest(OpenIDExtension):
+    ns_uri = "http://ns.login.ubuntu.com/2016/openid-macaroon"
+    ns_alias = "macaroon"
+
+    def __init__(self, caveat_id):
+        self.caveat_id = caveat_id
+
+    def getExtensionArgs(self):
+        """
+        Return the arguments to add to the OpenID request query
+        """
+    
+        return {"caveat_id": self.caveat_id}
+
+
+class MacaroonResponse(OpenIDExtension):
+    ns_uri = "http://ns.login.ubuntu.com/2016/openid-macaroon"
+    ns_alias = "macaroon"
+
+    def getExtensionArgs(self):
+        """
+        Return the arguments to add to the OpenID request query
+        """
+
+        return {"discharge": self.discharge}
+
+    def fromSuccessResponse(cls, success_response, signed_only=True):
+        self = cls()
+        if signed_only:
+            args = success_response.getSignedNS(self.ns_uri)
+        else:
+            args = success_response.message.getArgs(self.ns_uri)
+
+        if not args:
+            return None
+
+        self.discharge = args["discharge"]
+
+        return self
+
+    fromSuccessResponse = classmethod(fromSuccessResponse)


### PR DESCRIPTION
## [API documentation](https://docs.google.com/document/d/1FpN-S8EbJzFBr5BvHPGT4zostqcqI8GxxNQI_HDR5w4/edit)

## Done

- [x] Imported macaroons functions
- [x] Stored macaroon root and discharge in session
- [x] Fixed lint errors with `flake8 webapp` and `black --line-length 79 webapp`.

## QA

- Check out this feature branch
- Turn on your VPN
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Try login `/login`

## Issue / Card

Fixes #3 
