### PR TITLE
Revert invitation_code

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,6 +10,9 @@ class TestRoutes(unittest.TestCase):
         app.testing = True
         self.client = app.test_client()
 
+    def tearDown(self):
+        pass
+
     def test_homepage(self):
         """
         When given the index URL,
@@ -17,6 +20,14 @@ class TestRoutes(unittest.TestCase):
         """
 
         self.assertEqual(self.client.get("/").status_code, 200)
+
+    def test_thank_you(self):
+        """
+        When given the index URL,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/thank-you").status_code, 200)
 
     def test_not_found(self):
         """
@@ -31,10 +42,9 @@ class TestRoutes(unittest.TestCase):
         Demo page should redirect to login if no session.
         """
         response = self.client.get("/demo")
+        demo_uri = "http://localhost/login?next=/demo"
         self.assertEqual(self.client.get("/demo").status_code, 302)
-        self.assertEqual(
-            response.location, "http://localhost/login?next=/demo"
-        )
+        self.assertEqual(response.location, demo_uri)
 
     def test_demo_login(self):
         """
@@ -44,6 +54,10 @@ class TestRoutes(unittest.TestCase):
         with self.client.session_transaction() as s:
             self.assertTrue("authentication_token" not in s)
 
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_logout(self):
+        """
+        When given the index URL,
+        we should return a 302 status code
+        """
+        self.test_demo_login()
+        self.assertEqual(self.client.get("/logout").status_code, 302)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -13,9 +13,7 @@ from posixpath import join as url_join
 
 
 LOGIN_URL = "https://login.ubuntu.com"
-# Only works with VPN
-# Change when deployed to production
-ANBOXCLOUD_API_BASE = "https://staging.demo-api.anbox-cloud.io/"
+ANBOXCLOUD_API_BASE = "https://demo-api.anbox-cloud.io/"
 
 session = requests.Session()
 app = FlaskBase(
@@ -146,7 +144,7 @@ def logout():
 def login_handler():
     if "authentication_token" in flask.session:
         return flask.redirect(open_id.get_next_url())
-
+    flask.session["invitation_code"] = request.args.get("invitation_code")
     response = _api_request(
         url_path="1.0/token", method="GET", params={"provider": "usso"}
     )
@@ -168,7 +166,6 @@ def login_handler():
 @app.route("/demo")
 @login_required
 def demo():
-    flask.session["invitation_code"] = request.args.get("invitation_code")
     authentication_token = flask.session["authentication_token"]
     authorization_header = {
         "Authorization": f"macaroon root={authentication_token}"


### PR DESCRIPTION
## Done

- [x] Reverted back to previous `/login?invitation_code=XXXX&next=/demo` format
- [x] Additional cleanup and change to production endpoint (towards making streaming work, regions are not available in staging)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Turn on VPN
- Login with user without invitation code ->  "http://0.0.0.0:8043/login" it will fail
- Login with user with invitation code -> "http://0.0.0.0:8043/login?invitation_code=XXXX&next=/demo" where XXXX needs to be generated by anbox-cloud API manually.
