### PR TITLE
Add terms and privacy pages

### DIFF
--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,3 @@
+<h1>Privacy policy</h1>
+
+

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,0 +1,88 @@
+<h1>Terms of Service</h1>
+
+<p>I agree that my use of the services are subject to my adherence to, and acceptance of, the Terms of Service*, Privacy Notice and Privacy Policy.
+  TERMS OF SERVICE
+  1. Introduction                
+  These Terms of Service cover your access to the Anbox Cloud Demo Service (“Anbox Cloud Demo”) made available by Canonical Group Limited ("Canonical", "us", "our" or "we") to you ("you" or "your") subject to and in accordance with these Terms of Service (the “Service”).
+  
+  Please read these Terms of Service carefully before you use the Services. By using Services, you agree to become bound by these Terms of Service. You may not use the Service for illegal or unauthorised purposes or otherwise in accordance with these Terms of Service.
+  
+  If you are entering into these Terms of Service on behalf of a company or legal entity, you represent that you have authority to bind such company or legal entity, its officers, employees and agents and all users who access the Service through the account, to these Terms of Service. “you” and “your” shall refer to the company or legal entity and such users. If you do not have such authority do not accept these Terms of Service.
+  
+  You must be at least 13 years old to use the Service. If you are between age 13 and 18, we require your parent's or legal guardian's consent to use of the Services, please contact us at legal@canonical.com.
+  
+  Any change or update to the Services or Terms of Service will be made in accordance with section 6 below.
+  
+  2. Services 
+  The Service enables you to access a demo of Anbox Cloud (https://anbox-cloud.io) which includes streaming an Android system from the cloud. 
+  
+  3. Account
+  You will need an account to access and use the Service. We reserve the right to reject your request for an account or to immediately cancel or suspend your account and your use of the Services at any time if you do not comply with the following requirements. You must not attempt to create an account or use the Service if doing so would violate these Terms of Service. You must:    
+  
+  have a Service account
+  not use the Service for illegal or unauthorised purposes (or which encourage or permit illegal or authorised purposes), in infringement of a third party's’ rights or otherwise in accordance with these Terms of Service
+  not take any action or use the Service in any way that might bring Canonical into disrepute or affect the ability of Canonical to provide the Service     
+  not use the Service in any manner that might be libellous or defamatory, that contains threats or incites violence towards individuals or entities, or that violates the privacy rights of any third party     
+  not be located in or use the Services in an OFAC/EAR embargoed or sanctioned country or be on the U.S. Commerce Department’s Denied Persons List, Entity List, or Unverified List
+  
+  In order to access the Anbox Cloud Demo you will require an invitation code and a Single Sign On account with Canonical. If you do not have an account you will need to create one. You are responsible for choosing an appropriate password for your accounts and for keeping such password secure. Canonical will not ask you for your password and you should not reveal it to anyone. You are responsible for keeping your account details up to date.     
+  
+  4. End of Service
+  
+  We look forward to providing you with the Service for a limited trial period only. The trial period will be specified on the invitation code and may differ from user to user. However, there are also some circumstances under which the Service may be suspended or terminated:
+  
+  We cease to make the Service (or any part thereof) available
+  By us at any time as described in Section 3 above     
+  
+  We may also cease to offer the Services for any other reason, in which case we will provide you with notice on your account page.     
+  
+  6. Changes
+  
+  We aim to continually improve the delivery and content of the Service and accordingly may make changes to the Service throughout the trial.     
+      
+  This Service is offered on a trial basis, and your use of this Service  will be limited to the period of your trial. New features may be added, but we may also modify or discontinue (temporarily or permanently) part of the Service, in part or in whole before the end of the trial period.  
+      
+  In the event of a material change to the Service, we will notify you on your account page. What constitutes a material change in this circumstance will be determined by Canonical, in good faith and using common sense and reasonable judgment.     
+      
+  Similarly, we may occasionally make changes to these Terms of Service and will notify you of material changes either by email or on your account page. If Canonical does make changes to these Terms of Service, all changes will go into effect at the time we post the updated Terms of Service on your account page or as otherwise notified at that time.
+  7. Intellectual property 
+  
+  You have a non-exclusive, non-transferable (to the extent permitted by law) right to view, access and use the Services for such time as it is made available by us strictly in accordance with these Terms of Service.
+  
+  You will not acquire any rights to the Service (or the intellectual property rights contained therein) from your use of the Service, other than as set out in these Terms of Service.
+  
+  8. Personal data
+  
+  In order to provide the Service to you, you will be required to provide information about yourself such as your name, address, job title and company. Any such information you provide to Canonical must always be accurate, correct and up to date.     
+      
+  Our Privacy Notice and Privacy Policy explain how we treat your personal data and protect your privacy when using the Services and our services in general. Canonical may provide limited personal data, such as your name, email address and related information, to third parties Ampere Computing LLC with a registered office at 4655 Great America Pkwy Suite 601 Santa Clara, CA 95054, United States and Packet Host Inc., with a registered office in 30 Vesey Street, New York, 10007 NY, United States. By accessing the Anbox Cloud Demo you are agreeing to the use of your personal data in this way.
+  
+  We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.     
+  
+  Canonical may disclose any or all personal data and contents you have sent, posted or published if required to comply with applicable law or the order or requirement of a court, administrative agency or other governmental body. All other use of your personal data is subject to the Privacy Policy.
+  9. Liability
+  Your use of the Service is at your sole risk. The Service is provided on an “as is” and “as available” basis without warranty of any kind.
+  
+  In the case of the Service provided by Canonical, the Service is provided “as is” and, other than as expressly set out in these Terms of Service, all warranties (whether express, implied, statutory or otherwise) in respect of the Services are expressly excluded to the maximum extent permitted by law.    
+      
+  Canonical will provide the Services with reasonable care and skill, and Canonical will use reasonable efforts to ensure the availability of the Services, but makes no guarantee that the Services will be available without interruption or will be error-free.
+  
+  Canonical will not be liable in contract, tort or otherwise for any: indirect or consequential loss; loss of profits; loss of revenue; loss of anticipated savings; loss of business or business opportunity; loss of goodwill; or loss of or corruption to data. Otherwise, Canonical’s total liability in contract, tort or otherwise for any claims is limited to £10.
+  
+  Nothing in these Terms of Service will exclude or limit Canonical’s liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.
+  
+  9. General
+  These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.     
+  
+  Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.     
+  
+  Any notices should be sent by email to legal@canonical.com or by registered post to:
+  
+  Canonical Group Limited, 
+  5th Floor, Blue Fin Building, 
+  110 Southwark Street, 
+  London, SE1 0SU.
+  
+  Version: January 2020
+  
+  </p>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -61,3 +61,19 @@ class TestRoutes(unittest.TestCase):
         """
         self.test_demo_login()
         self.assertEqual(self.client.get("/logout").status_code, 302)
+
+    def test_terms(self):
+        """
+        When given the index URL,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/terms").status_code, 200)
+
+    def test_privacy(self):
+        """
+        When given the index URL,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/privacy").status_code, 200)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -79,6 +79,16 @@ def thank_you():
     return flask.render_template("thank-you.html")
 
 
+@app.route("/terms")
+def terms():
+    return flask.render_template("terms.html")
+
+
+@app.route("/privacy")
+def privacy():
+    return flask.render_template("privacy.html")
+
+
 @open_id.after_login
 def after_login(resp):
     """


### PR DESCRIPTION
## Done

Created legal pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- View new legal pages http://0.0.0.0:8043/terms, http://0.0.0.0:8043/privacy


## Issue / Card

Fixes #56 