### PR TITLE
Handle stun_servers null

### DIFF
--- a/static/js/anbox-stream-sdk.js
+++ b/static/js/anbox-stream-sdk.js
@@ -142,7 +142,7 @@ class AnboxStream {
             }
 
             // If we received any additional STUN/TURN servers from the gateway use them
-            if (jsonResp.metadata.stun_servers.length > 0)
+            if (jsonResp.metadata.stun_servers.length > 0 && jsonResp.metadata.stun_servers !== null)
                 this._options.stunServers.concat(jsonResp.metadata.stun_servers);
 
             this._connectSignaler(jsonResp.metadata.websocket_url);


### PR DESCRIPTION
## Done

- [x] `jsonResp.metadata.stun_servers`null was unhandled. It seems it just takes time to fill in the stun_servers
- [ ] webrtc error

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://localhost:8043/ (for the webrtc issue, @nottrobin can you try using localhost instead of 0.0.0.0 see if it works?)
- Go to `http://localhost:8043/demo`


## Issue / Card

Fixes #62 

## Screenshots

<img width="1423" alt="Screenshot 2020-02-07 at 14 59 26" src="https://user-images.githubusercontent.com/14939793/74039936-a4738400-49ba-11ea-89fc-31829ee86333.png">

