### PR TITLE
static: handle stun servers from API response correctly

### DIFF
--- a/static/js/anbox-stream-sdk.js
+++ b/static/js/anbox-stream-sdk.js
@@ -138,8 +138,16 @@ class AnboxStream {
                 throw new Error(jsonResp.error)
 
             // If we received any additional STUN/TURN servers from the gateway use them
-            if (jsonResp.metadata.stun_servers.length > 0)
-                this._options.stunServers.concat(jsonResp.metadata.stun_servers);
+            // If we received any additional STUN/TURN servers from the gateway use them
+            if (!this._nullOrUndef(jsonResp.metadata.stun_servers) && jsonResp.metadata.stun_servers.length > 0) {
+                for (var n = 0; n < jsonResp.metadata.stun_servers.length; n++) {
+                    this._options.stunServers.push({
+                        "urls": jsonResp.metadata.stun_servers[n].urls,
+                        "username": jsonResp.metadata.stun_servers[n].username,
+                        "credential": jsonResp.metadata.stun_servers[n].password
+                    });
+                }
+            }
 
             this._connectSignaler(jsonResp.metadata.websocket_url);
         })


### PR DESCRIPTION
We may either get passed STUN servers or not. Also we have to do some
conversion of the passed list as the Web API expects "credential" rather
than "password" for TURN servers.

## Done

n/a

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

n/a

## Screenshots

n/a
