### PR TITLE
Handle expired tokens

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -179,6 +179,7 @@ def demo():
     authorization_header = {
         "Authorization": f"macaroon root={authentication_token}"
     }
+    # to be removed in the future
     _api_request("/1.0/instances", headers=authorization_header)
     return flask.render_template(
         "demo.html", ANBOXCLOUD_API_BASE=ANBOXCLOUD_API_BASE
@@ -190,4 +191,5 @@ def handle_unauthorised(error):
     """
     Handle 401 errors using flask as opposed to requests
     """
+    flask.session.pop("authentication_token", None)
     return flask.render_template("401.html", error=error.description), 401


### PR DESCRIPTION
## Done

- [x] When user has expired token or changes browser (session changed) remove token so it can redirect to `/login` again

This is a temporary fix, until we can get anbox-cloud API's error codes, so we can differentiate between "invalid token" and "invalid invitation code" among other errors.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/login?&next=/demo&invitation_code=XXXX
- Or if you already allowed access you don't need invitation code `http://0.0.0.0:8043/demo`
- After session expires (24hrs) it should require you to "relogin". One way to hack this is to open it in another browser (invalidates the other session) and go back and hit `/demo`

## Issue / Card

Fixes #70 

