### PR TITLE
Handle expired tokens with error codes

### DIFF
--- a/templates/demo.html
+++ b/templates/demo.html
@@ -7,37 +7,56 @@
 {% block content %}
 <script type="module">
   import AnboxStream from '/static/js/anbox-stream-sdk.js';
-  // @ params buttonId: HTML id of the button that activates it
-  // @ params anboxStreamId: HTML id attribute of the div containing the anbox stream
-  function streamContainer(anboxStreamId) {
-    let stream = new AnboxStream({
-    targetElement: anboxStreamId,
-    url: '{{ ANBOXCLOUD_API_BASE }}',
-    authToken: '{{ session["authentication_token"] }}',
-    session: {
-        app: "com.vectorunit.cobalt.canonical", // Given
-    },
-    screen: {
-      // Currently available max resolution
-      // To change to portrait just flip the values between width and height
-        width: 1280,
-        height: 720,
-    },
-    // Using keyboard controls to test it on non-touch device
-    controls: {
-      keyboard: true
-    },
-    callbacks: {
-      error: error => {
-        console.log("AnboxStream failed: " + error.message);
-      }
+  // @ params appName: name of the application to stream
+  function streamContainer(appName, height = false, width = false) {
+    var container = document.querySelector('#' + appName);
+    var errorContainer = container.querySelector(".js-error-container");
+    var errorMessage = container.querySelector(".js-error");
+    var button = container.querySelector(".js-button");
+    var player = document.querySelector('#' + appName + "-player");
+    var loading = container.querySelector(".js-loading");
+    var play = container.querySelector(".js-play");
+
+    if (loading.classList.contains("u-hide")) {
+      play.classList.add("u-hide");
+      loading.classList.remove("u-hide");
+      errorContainer.classList.add('u-hide');
+
+      let stream = new AnboxStream({
+        targetElement: player.id,
+        url: '{{ ANBOXCLOUD_API_BASE }}',
+        authToken: '{{ session["authentication_token"] }}',
+        session: {
+          app: "com.vectorunit.cobalt.canonical", // Given
+        },
+        screen: {
+          width: width && width < 1104 ? width : 1104,
+          height: height && height < 628 ? height : 628,
+          fps: 25
+        },
+        // Using keyboard controls to test it on non-touch device
+        controls: {
+          keyboard: true
+        },
+        callbacks: {
+          error: error => {
+            button.classList.remove("u-hide");
+            player.classList.add('u-hide');
+            loading.classList.add("u-hide");
+            play.classList.remove("u-hide");
+            errorMessage.textContent = "Please click the play button below to try again.";
+            console.error('Anbox cloud stream error: ' + error);
+            errorContainer.classList.remove('u-hide');
+          },
+          ready: ready => {
+            button.classList.add("u-hide");
+            player.classList.remove('u-hide');
+          }
+        }
+      });
+      stream.connect();
     }
-  });
-  stream.connect();
   }
-
-  document.querySelector("#buggy-racing-btn").addEventListener('click', streamContainer("buggy-racing"))
-
   var streams = Array.from(document.querySelectorAll('.p-stream'));
 
   streams.forEach((stream, i) => {
@@ -55,9 +74,9 @@
   </div>
   <div class="row">
     <div class="col-12 u-align--center">
-      <button type="button" id="buggy-racing-btn">Click here to start anbox stream</button>
-      <div id="buggy-racing"></div>
-      <!-- <img src="https://via.placeholder.com/1280x720" alt=""> -->
+      {% with app="buggy-racing" %}
+        {% include "_anbox-embed.html" %}
+      {% endwith %}
     </div>
   </div>
 </section>

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -7,56 +7,36 @@
 {% block content %}
 <script type="module">
   import AnboxStream from '/static/js/anbox-stream-sdk.js';
-  // @ params appName: name of the application to stream
-  function streamContainer(appName, height = false, width = false) {
-    var container = document.querySelector('#' + appName);
-    var errorContainer = container.querySelector(".js-error-container");
-    var errorMessage = container.querySelector(".js-error");
-    var button = container.querySelector(".js-button");
-    var player = document.querySelector('#' + appName + "-player");
-    var loading = container.querySelector(".js-loading");
-    var play = container.querySelector(".js-play");
-
-    if (loading.classList.contains("u-hide")) {
-      play.classList.add("u-hide");
-      loading.classList.remove("u-hide");
-      errorContainer.classList.add('u-hide');
-
-      let stream = new AnboxStream({
-        targetElement: player.id,
-        url: '{{ ANBOXCLOUD_API_BASE }}',
-        authToken: '{{ session["authentication_token"] }}',
-        session: {
-          app: "com.vectorunit.cobalt.canonical", // Given
-        },
-        screen: {
-          width: width && width < 1104 ? width : 1104,
-          height: height && height < 628 ? height : 628,
-          fps: 25
-        },
-        // Using keyboard controls to test it on non-touch device
-        controls: {
-          keyboard: true
-        },
-        callbacks: {
-          error: error => {
-            button.classList.remove("u-hide");
-            player.classList.add('u-hide');
-            loading.classList.add("u-hide");
-            play.classList.remove("u-hide");
-            errorMessage.textContent = "Please click the play button below to try again.";
-            console.error('Anbox cloud stream error: ' + error);
-            errorContainer.classList.remove('u-hide');
-          },
-          ready: ready => {
-            button.classList.add("u-hide");
-            player.classList.remove('u-hide');
-          }
-        }
-      });
-      stream.connect();
+  // @ params buttonId: HTML id of the button that activates it
+  // @ params anboxStreamId: HTML id attribute of the div containing the anbox stream
+  function streamContainer(anboxStreamId) {
+    let stream = new AnboxStream({
+    targetElement: anboxStreamId,
+    url: '{{ ANBOXCLOUD_API_BASE }}',
+    authToken: '{{ session["authentication_token"] }}',
+    session: {
+        app: "com.vectorunit.cobalt.canonical", // Given
+    },
+    screen: {
+      // Currently available max resolution
+      // To change to portrait just flip the values between width and height
+        width: 1280,
+        height: 720,
+    },
+    // Using keyboard controls to test it on non-touch device
+    controls: {
+      keyboard: true
+    },
+    callbacks: {
+      error: error => {
+        console.log("AnboxStream failed: " + error.message);
+      }
     }
+  });
+  stream.connect();
   }
+
+  document.querySelector("#buggy-racing-btn").addEventListener('click', streamContainer("buggy-racing"))
 
   var streams = Array.from(document.querySelectorAll('.p-stream'));
 
@@ -75,9 +55,9 @@
   </div>
   <div class="row">
     <div class="col-12 u-align--center">
-      {% with app="buggy-racing" %}
-        {% include "_anbox-embed.html" %}
-      {% endwith %}
+      <button type="button" id="buggy-racing-btn">Click here to start anbox stream</button>
+      <div id="buggy-racing"></div>
+      <!-- <img src="https://via.placeholder.com/1280x720" alt=""> -->
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- [x] Relogin after expired token


## QA

The API returns invalid 401 HTTP error with [900 error code](https://docs.google.com/document/d/1FpN-S8EbJzFBr5BvHPGT4zostqcqI8GxxNQI_HDR5w4/edit) for any invalid tokens (macaroons). This includes:
- Expired token
- Invalid token (changed)
- Session closed and reopened
...

Therefore, to replicate this error I used the last one which returns the same response as an expired token - session changed. This is sort of a hack to QA this, so it may not always work, sometimes sessions seem to persist:

- Run the project with latest code `./run`
- Go to demo page http://localhost:8043/demo
- Go to another browser with a new session or open incognito and do it again. You should be redirected to login.
- Or wait 24 hours until token is expired and I should also get the same result, redirected to login.

## Issues

Fixes #70 