### PR TITLE
Add black background to player wrapper

### DIFF
--- a/static/sass/_pattern_stream.scss
+++ b/static/sass/_pattern_stream.scss
@@ -12,6 +12,10 @@
     width: 100px;
   }
 
+  .p-stream__player {
+    background-color: #000;
+  }
+
   .p-stream__error {
     left: $sph-inner;
     position: absolute;


### PR DESCRIPTION
## Done

Added a black background to the player wrapper to avoid flickering when loading the stream

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/demo
