### PR TITLE
streaming: go fullscreen when starting a stream on a mobile device

### DIFF
--- a/templates/demo.html
+++ b/templates/demo.html
@@ -48,9 +48,20 @@
             console.error('Anbox cloud stream error: ' + error);
             errorContainer.classList.remove('u-hide');
           },
-          ready: ready => {
+          ready: () => {
             button.classList.add("u-hide");
             player.classList.remove('u-hide');
+            if (navigator.userAgent.match(/Android/i)
+                    || navigator.userAgent.match(/webOS/i)
+                    || navigator.userAgent.match(/iPhone/i)
+                    || navigator.userAgent.match(/iPad/i)
+                    || navigator.userAgent.match(/iPod/i)
+                    || navigator.userAgent.match(/BlackBerry/i)
+                    || navigator.userAgent.match(/Windows Phone/i))
+            {
+              console.log("SDK: detected mobile browser, trying to enable fullscreen");
+              stream.requestFullscreen();
+            }
           }
         }
       });


### PR DESCRIPTION
## Done

Enable fullscreen is a mobile device is detected
If better methods for detecting mobile devices are known, feel free to suggest it
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]
