### PR TITLE
Fix json format to normal string

### DIFF
--- a/templates/401.html
+++ b/templates/401.html
@@ -11,7 +11,7 @@
     <div class="col-6 u-vertically-center">
       <div>
         <h1>401: Unauthorised</h1>
-        <p class="p-heading--four">{{ error }}.</p>
+        <p class="p-heading--four">{{ error.capitalize() }}.</p>
       </div>
     </div>
   </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -194,4 +194,7 @@ def handle_unauthorised(error):
         flask.session.pop("authentication_token", None)
         return flask.redirect("/login?next=" + flask.request.path)
 
-    return flask.render_template("401.html", error=error.description), 401
+    return (
+        flask.render_template("401.html", error=error.description["error"]),
+        401,
+    )


### PR DESCRIPTION
## Done

So because of the API change to add the code errors, I have to change the way error is shown.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/demo
- To see this you need to use an SSO account which does not have an invitation code assigned: http://0.0.0.0:8043/login?&next=/demo&invitation_code={invitation_code}

## Issue / Card

Fixes #82 

## Screenshots

Before:
![Screenshot 2020-02-19 at 15 49 07](https://user-images.githubusercontent.com/14939793/74849536-b9440600-5330-11ea-95f7-b26c03cd8351.png)

After:
![Screenshot 2020-02-19 at 15 49 45](https://user-images.githubusercontent.com/14939793/74849574-c52fc800-5330-11ea-8aa0-1d1179224f1d.png)
