### PR TITLE
Add instructions to the stream placeholder

### DIFF
--- a/static/sass/_pattern_stream.scss
+++ b/static/sass/_pattern_stream.scss
@@ -26,6 +26,13 @@
     }
   }
 
+  .p-stream__instructions {
+    bottom: $spv-inner--medium;
+    left: $sph-inner;
+    position: absolute;
+    text-align: left;
+  }
+
   .p-stream__error {
     left: $sph-inner;
     position: absolute;

--- a/templates/_anbox-embed.html
+++ b/templates/_anbox-embed.html
@@ -9,5 +9,12 @@
       </p>
     </div>
   </a>
+  {% if app == "buggy-racing" %}
+  <div class="p-stream__instructions p-card--overlay">
+    <h3 class="p-heading--four">Game controls</h3>
+    <p><span title="up arrow key">↑</span><span title="down arrow key">↓</span><span title="left arrow key">←</span><span title="right arrow key">→</span>: movement</p>
+    <p><span title="A key">🄰</span><span title="S key">🅂</span><span title="D key">🄳</span>: trigger power-ups</p>
+  </div>
+  {% endif %}
   <div id="{{ app }}-player" class="p-stream__player js-player u-hide"></div>
 </div>


### PR DESCRIPTION
## Done

Added an overlay of the game controls

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/demo
- Check that the instructions are visible and not

