### PR TITLE
static: hide video media controls in fullscreen mode

### DIFF
--- a/static/sass/_pattern_stream.scss
+++ b/static/sass/_pattern_stream.scss
@@ -24,6 +24,13 @@
       background-color: #000;
       margin: 0;
     }
+
+    // Ensure we always hide the media controls of the player, even in fullscreen.
+    // See https://css-tricks.com/custom-controls-in-html5-video-full-screen/ for
+    // more details
+    video::-webkit-media-controls {
+      display:none !important;
+    }
   }
 
   .p-stream__instructions {

--- a/static/sass/_pattern_stream.scss
+++ b/static/sass/_pattern_stream.scss
@@ -21,16 +21,18 @@
     top: 0;
 
     video {
-      background-color: #000;
+      background-color:  $color-x-dark;
       margin: 0;
     }
 
+    // sass-lint:disable no-vendor-prefixes
     // Ensure we always hide the media controls of the player, even in fullscreen.
     // See https://css-tricks.com/custom-controls-in-html5-video-full-screen/ for
     // more details
     video::-webkit-media-controls {
-      display:none !important;
+      display: none !important;
     }
+    // sass-lint:enable no-vendor-prefixes
   }
 
   .p-stream__instructions {


### PR DESCRIPTION
Chrome doesn't reliable hide the media controls when switching into
fullscreen mode. The only way to completely hide them is by manipulating
the shadow dom of the video element. See the linked blog post for more
details.

As I am not an CSS/SASS expert happy for any suggestions.

## Done

n/a

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

n/a

## Screenshots

n/a
