### PR TITLE
Hide keyboard controls on mobile

### DIFF
--- a/static/js/detect-device.js
+++ b/static/js/detect-device.js
@@ -1,0 +1,11 @@
+export default function mobileDevice(navigator) {
+    if (navigator.userAgent.match(/Android/i)
+        || navigator.userAgent.match(/webOS/i)
+        || navigator.userAgent.match(/iPhone/i)
+        || navigator.userAgent.match(/iPad/i)
+        || navigator.userAgent.match(/iPod/i)
+        || navigator.userAgent.match(/BlackBerry/i)
+        || navigator.userAgent.match(/Windows Phone/i))
+        return true
+    return false
+}

--- a/static/js/detect-device.js
+++ b/static/js/detect-device.js
@@ -1,4 +1,4 @@
-export default function mobileDevice(navigator) {
+export default function mobileDevice() {
     if (navigator.userAgent.match(/Android/i)
         || navigator.userAgent.match(/webOS/i)
         || navigator.userAgent.match(/iPhone/i)

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -9,7 +9,7 @@
   import AnboxStream from '/static/js/anbox-stream-sdk.js';
   import mobileDevice from '/static/js/detect-browser.js';
 
-  if (mobileDevice(navigator)) {
+  if (mobileDevice()) {
     document.querySelector('.p-stream__instructions').classList.add("u-hide")
   }
 

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -7,6 +7,12 @@
 {% block content %}
 <script type="module">
   import AnboxStream from '/static/js/anbox-stream-sdk.js';
+  import mobileDevice from '/static/js/detect-browser.js';
+
+  if (mobileDevice(navigator)) {
+    document.querySelector('.p-stream__instructions').classList.add("u-hide")
+  }
+
   // @ params appName: name of the application to stream
   function streamContainer(appName) {
     var container = document.querySelector('#' + appName);
@@ -62,13 +68,7 @@
             }
             placeholder.style.opacity = 0;
             player.classList.remove('u-hide');
-            if (navigator.userAgent.match(/Android/i)
-                    || navigator.userAgent.match(/webOS/i)
-                    || navigator.userAgent.match(/iPhone/i)
-                    || navigator.userAgent.match(/iPad/i)
-                    || navigator.userAgent.match(/iPod/i)
-                    || navigator.userAgent.match(/BlackBerry/i)
-                    || navigator.userAgent.match(/Windows Phone/i))
+          if (mobileDevice(navigator))
             {
               console.log("SDK: detected mobile browser, trying to enable fullscreen");
               stream.requestFullscreen();


### PR DESCRIPTION
## Done

I guess if we have to check for mobile frequently, I thought it would be good to refactor @aguadoenzo mobile check in a function, and I also used this to hide the controls.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Check on mobile that the controls hide. You can simulate this with developer tools in mobile mode.
- Also should QA back if normal OS mode.

## Issue / Card

Fixes #86
