### PR TITLE
Small/mobile screens

### DIFF
--- a/static/sass/_pattern_stream.scss
+++ b/static/sass/_pattern_stream.scss
@@ -36,10 +36,13 @@
   }
 
   .p-stream__instructions {
-    bottom: $spv-inner--medium;
-    left: $sph-inner;
-    position: absolute;
     text-align: left;
+
+    @media (min-width: $breakpoint-medium) {
+      bottom: $spv-inner--medium;
+      left: $sph-inner;
+      position: absolute;
+    }
   }
 
   .p-stream__error {

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -68,7 +68,7 @@
             }
             placeholder.style.opacity = 0;
             player.classList.remove('u-hide');
-          if (mobileDevice(navigator))
+          if (mobileDevice())
             {
               console.log("SDK: detected mobile browser, trying to enable fullscreen");
               stream.requestFullscreen();

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -7,7 +7,7 @@
 {% block content %}
 <script type="module">
   import AnboxStream from '/static/js/anbox-stream-sdk.js';
-  import mobileDevice from '/static/js/detect-browser.js';
+  import mobileDevice from '/static/js/detect-device.js';
 
   if (mobileDevice()) {
     document.querySelector('.p-stream__instructions').classList.add("u-hide")


### PR DESCRIPTION
- ~~Hide controls when a mobile user agent is detected (JS)~~ Already landed in #89
- Reposition controls when a small browser is detected (CSS)
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/demo (authenticate with an invite code first)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check small viewports - the instructions box should be under the demo
- Check using a mobile use agent ("Android" for instance) - the instructions box should not be visible


## Issue / Card

Fixes #86 