### PR TITLE
streaming: reset the stream and placeholder when leaving fullscreen on mobile

### DIFF
--- a/templates/demo.html
+++ b/templates/demo.html
@@ -18,14 +18,23 @@
     var play = container.querySelector(".js-play");
     var placeholder = container.querySelector('.js-placeholder');
 
-    var containerHeight = container.offsetHeight;
-    var containerWidth = container.offsetWidth;
-
-    if (loading.classList.contains("u-hide")) {
+    const hidePlaceholder = () => {
       play.classList.add("u-hide");
       loading.classList.remove("u-hide");
       errorContainer.classList.add('u-hide');
+      placeholder.style.opacity = 1
+    };
+
+    const showPlacerholder = () => {
+      button.classList.remove("u-hide");
+      player.classList.add('u-hide');
+      loading.classList.add("u-hide");
+      play.classList.remove("u-hide");
       placeholder.style.opacity = 1;
+    };
+
+    if (loading.classList.contains("u-hide")) {
+      hidePlaceholder();
 
       let stream = new AnboxStream({
         targetElement: player.id,
@@ -44,15 +53,14 @@
           keyboard: true
         },
         callbacks: {
+          done: () => {
+            showPlacerholder();
+          },
           error: error => {
-            button.classList.remove("u-hide");
-            player.classList.add('u-hide');
-            loading.classList.add("u-hide");
-            play.classList.remove("u-hide");
-            placeholder.style.opacity = 1;
+            showPlacerholder();
             errorMessage.textContent = "Please click the play button below to try again.";
-            console.error('Anbox cloud stream error: ' + error);
             errorContainer.classList.remove('u-hide');
+            console.error('Anbox cloud stream error: ' + error);
           },
           ready: () => {
             var video = player.querySelector('video');
@@ -76,6 +84,14 @@
           }
         }
       });
+
+      document.onfullscreenchange = () => {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Document/onfullscreenchange
+        if (document.fullscreenElement === null) {
+          stream.disconnect();
+        }
+      };
+
       stream.connect();
     }
   }


### PR DESCRIPTION
When starting the stream on mobile, the video would go fullscreen. When exiting fullscreen however, the stream would keep going and be unusable. This commit fixes that by stopping the stream on exiting fullscreen

## Done

[List of work items including drive-bys]

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
