### PR TITLE
Update phone label to mobile/cell

### DIFF
--- a/templates/_engage-form.html
+++ b/templates/_engage-form.html
@@ -2,12 +2,12 @@
 <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="marketo-form" id="mktoForm_{{ id }}">
     <ul class="p-list">
       <li class="mktFormReq mktField p-list__item">
-        <label for="FirstName" class="mktoLabel">First Name:</label>
+        <label for="FirstName" class="mktoLabel">First name:</label>
         <input required id="FirstName" name="FirstName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="First Name">
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="LastName" class="mktoLabel ">Last Name:</label>
+        <label for="LastName" class="mktoLabel ">Last name:</label>
         <input required id="LastName" name="LastName" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Last Name">
       </li>
@@ -17,16 +17,16 @@
           aria-label="Email">
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="Company" class="mktoLabel ">Company Name:</label>
+        <label for="Company" class="mktoLabel ">Company name:</label>
         <input required id="Company" name="Company" maxlength="255" class="mktoField   mktoRequired" type="text"
           aria-label="Company Name">
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="Title" class="mktoLabel ">Job Title:</label>
+        <label for="Title" class="mktoLabel ">Job title:</label>
         <input required id="Title" name="Title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
       </li>
       <li class="mktFormReq mktField p-list__item">
-        <label for="Phone" class="mktoLabel ">Phone Number:</label>
+        <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
         <input required id="Phone" name="Phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
           aria-label="Phone Number">
       </li>
@@ -42,8 +42,7 @@
       </li>
       <li class="mktField">
         <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
-          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">I agree to receive
-          information about Canonical’s products and services.</label>
+          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">I agree to receive information about Canonical’s products and services.</label>
       </li>
       <li class="mktField">
         <p>In submitting this form, I confirm that I have read and agree to <a href="https://ubuntu.com/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy">Privacy Policy</a>.


### PR DESCRIPTION
## Done

- Update phone label to mobile/cell
- Sentence case other form labels

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1m3hL6Y8VqFqeZLy-sewPAyCZz-uGr7zfqzNwtGumyho/edit)


## Issue / Card

Fixes #93

