### PR TITLE
Set API token as cookie for other services to make use of it

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -181,9 +181,13 @@ def demo():
     }
     # to be removed in the future
     _api_request("/1.0/instances", headers=authorization_header)
-    return flask.render_template(
+
+    content = flask.render_template(
         "demo.html", ANBOXCLOUD_API_BASE=ANBOXCLOUD_API_BASE
     )
+    resp = flask.make_response(content)
+    resp.set_cookie("api_token", authentication_token)
+    return resp
 
 
 @app.errorhandler(401)


### PR DESCRIPTION
When using the login process of the website within a webview inside an
Android application we need a way to extract the API token which wasn't
possible so far. The token was only written as a Javascript variable in
the site code but not available as a cookie.

## Done

n/a

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

n/a

## Screenshots

n/a
