### PR TITLE
Upgrade to use gevent

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -2,7 +2,7 @@
 
 set -e
 
-RUN_COMMAND="talisker.gunicorn webapp.app:app --bind $1 --worker-class sync --workers 2 --name talisker-`hostname`"
+RUN_COMMAND="talisker.gunicorn.gevent webapp.app:app --bind $1 --worker-class gevent --name talisker-`hostname`"
 
 if [ "${FLASK_DEBUG}" = true ] || [ "${FLASK_DEBUG}" = 1 ]; then
     RUN_COMMAND="${RUN_COMMAND} --reload --log-level debug --timeout 9999"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==0.4.3
+canonicalwebteam.flask-base==0.6.0
 Flask-OpenID-Stateless==1.2.6
 requests==2.23.0
 responses==0.10.12


### PR DESCRIPTION
## Done

- Update talisker v0.18.0
- Use gevent

## QA

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag anbox-cloud.io .`
-  `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key anbox-cloud.io`
- http://0.0.0.0:8006/
- Play around with the site and make sure it works well 