### PR TITLE
Anbox docs test and other fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "scripts": {
-    "start": "yarn run build && yarn run serve",
+    "start": "yarn run build && concurrently --kill-others --raw 'yarn run watch' 'yarn run serve'",
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
     "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
@@ -17,11 +17,14 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.1",
+    "vanilla-framework": "2.13.0"
+  },
+  "devDependencies": {
     "autoprefixer": "9.8.4",
+    "concurrently": "5.2.0",
     "node-sass": "4.14.1",
     "postcss-cli": "7.1.1",
     "sass-lint": "1.13.1",
-    "vanilla-framework": "2.13.0",
     "watch-cli": "0.2.3"
   }
 }

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="p-strip is-shallow">
-  <div class="row">
+  <div class="row u-no-padding">
     <aside class="col-3">
       <nav class="p-side-navigation--raw-html" id="drawer">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
@@ -30,11 +30,6 @@
       {{ document.body_html | safe }}
       <hr />
       <p><i>Last updated {{ document.updated }}.</i></p>
-      <div class="p-notification--information">
-        <p class="p-notification__response">
-          <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.
-        </p>
-      </div>
     </main>
   </div>
 </div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -74,3 +74,11 @@ class TestRoutes(unittest.TestCase):
         """
 
         self.assertEqual(self.client.get("/privacy").status_code, 200)
+
+    def test_docs(self):
+        """
+        When given the index URL,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/docs").status_code, 200)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -44,8 +44,7 @@ discourse_docs = DiscourseDocs(
         api=DiscourseAPI(
             base_url="https://discourse.ubuntu.com/", session=session
         ),
-        category_id=49,
-        index_topic_id=17028,
+        index_topic_id=17029,
         url_prefix="/docs",
     ),
     document_template="docs/document.html",


### PR DESCRIPTION
## Done

- Fix topic id (it wasn't showing navigation)
- Add test
- Project clean up

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8043/docs
- Make sure it shows the navigation and it can be toggled (it should show more than 1 item)
- Make sure global nav is not missing
- Make sure tests pass the checks

## Issue / Card

Fixes #104 
