### PR TITLE
Revert discourse version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.discourse==3.0.2
+canonicalwebteam.discourse==2.1.0
 canonicalwebteam.flask-base==0.7.3
 Flask-OpenID-Stateless==1.2.6
 requests==2.25.1


### PR DESCRIPTION
## Done

Revert discourse module to 2.1.0

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/docs works
