### PR TITLE
Fix search results links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:12-slim AS yarn-dependencies
+FROM node:12 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install

--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -81,8 +81,8 @@
         <div class="col-6">
           <h3>Still no luck?</h3>
           <ul class="p-list">
-            <li class="p-list__item is-ticked"><a href="/docs">Visit jaas.io/docs</a></li>
-            <li class="p-list__item is-ticked"><a href="https://discourse.juju.is">Ask on the forum</a></li>
+            <li class="p-list__item is-ticked"><a href="/docs">Visit anbox-cloud.io/docs</a></li>
+            <li class="p-list__item is-ticked"><a href="https://discourse.ubuntu.com/c/anbox-cloud/49">Ask on the forum</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Done

Fix links on search results page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/docs
- Type random words or strings in order to find No Results
- If you go to current site https://anbox-cloud.io/docs you will see jaas.io in the links, in this PR it will be corrected.

## Issue / Card

Fixes #149 

