### PR TITLE
templates: mention OCI as supported cloud

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
   <div class="row u-vertically-center">
     <div class="col-6">
       <h1>Android containers<br/>in the cloud</h1>
-      <p class="u-sv2">Anbox Cloud lets you stream mobile apps securely, at any scale, to any device letting you focus on your apps. Run Android in system containers, not emulators, on AWS, Azure, GCP or your private cloud.</p>
+      <p class="u-sv2">Anbox Cloud lets you stream mobile apps securely, at any scale, to any device letting you focus on your apps. Run Android in system containers, not emulators, on AWS, OCI, Azure, GCP or your private cloud.</p>
       <p><a href="/contact-us" class="p-button--positive">Get Anbox Cloud</a></p>
     </div>
     <div class="col-6 u-align--cente">


### PR DESCRIPTION
## Done

Added OCI as supported cloud in the first paragraph

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card

n/a

## Screenshots

n/a
