### PR TITLE
4011 moble app management page build

### DIFF
--- a/templates/enterprise/index.html
+++ b/templates/enterprise/index.html
@@ -1,0 +1,37 @@
+{% extends '_layout.html' %}
+
+
+{% block title %}Enterprise. Secute mobile application management.{% endblock %}
+{% block meta_description %}Enterprise mobile application management. Driving digitalisation for mobile workforces.
+{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1YMfnGmUWZqs89uVyREdH9BzkHasp4b3RDV0FzS75K3I/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-half-and-half-reversed is-dark">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
+      <h1>
+        Enterprise mobile application management
+      </h1>
+      <p class="p-heading--four">
+        Driving digitalisation for mobile workforces
+      </p>
+    </div>
+    <div class="col-6 u-align--center u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4d799496-Anbox_MobAppManagement_Apps.svg",
+        alt="",
+        width="152",
+        height="195",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+
+
+{% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -136,6 +136,11 @@ def telco():
     return flask.render_template("telco/index.html")
 
 
+@app.route("/enterprise")
+def enterprise():
+    return flask.render_template("enterprise/index.html")
+
+
 @open_id.after_login
 def after_login(resp):
     """


### PR DESCRIPTION
## Done

- Built vertical page for 'Mobile app management'.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/enterprise
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against [copy-doc](https://docs.google.com/document/d/1YMfnGmUWZqs89uVyREdH9BzkHasp4b3RDV0FzS75K3I/edit#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4011
