### PR TITLE
Add appliance and deploy button linking to AWS

### DIFF
--- a/static/js/contextualMenu.js
+++ b/static/js/contextualMenu.js
@@ -1,0 +1,82 @@
+/**
+  Toggles the necessary aria- attributes' values on the menus
+  and handles to show or hide them.
+  @param {HTMLElement} element The menu link or button.
+  @param {Boolean} show Whether to show or hide the menu.
+  @param {Number} top Top offset in pixels where to show the menu.
+*/
+function toggleMenu(element, show, top) {
+    var target = document.getElementById(element.getAttribute('aria-controls'));
+
+    if (target) {
+      element.setAttribute('aria-expanded', show);
+      target.setAttribute('aria-hidden', !show);
+
+      if (typeof top !== 'undefined') {
+        target.style.top = top + 'px';
+      }
+
+      if (show) {
+        target.focus();
+      }
+    }
+  }
+
+  /**
+    Attaches event listeners for the menu toggle open and close click events.
+    @param {HTMLElement} menuToggle The menu container element.
+  */
+  function setupContextualMenu(menuToggle) {
+    menuToggle.addEventListener('click', function (event) {
+      event.preventDefault();
+      var menuAlreadyOpen = menuToggle.getAttribute('aria-expanded') === 'true';
+
+      var top = menuToggle.offsetHeight;
+      // for inline elements leave some space between text and menu
+      if (window.getComputedStyle(menuToggle).display === 'inline') {
+        top += 5;
+      }
+
+      toggleMenu(menuToggle, !menuAlreadyOpen, top);
+    });
+  }
+
+  /**
+    Attaches event listeners for all the menu toggles in the document and
+    listeners to handle close when clicking outside the menu or using ESC key.
+    @param {String} contextualMenuToggleSelector The CSS selector matching menu toggle elements.
+  */
+  function setupAllContextualMenus(contextualMenuToggleSelector) {
+    // Setup all menu toggles on the page.
+    var toggles = document.querySelectorAll(contextualMenuToggleSelector);
+
+    for (var i = 0, l = toggles.length; i < l; i++) {
+      setupContextualMenu(toggles[i]);
+    }
+
+    // Add handler for clicking outside the menu.
+    document.addEventListener('click', function (event) {
+      for (var i = 0, l = toggles.length; i < l; i++) {
+        var toggle = toggles[i];
+        var contextualMenu = document.getElementById(toggle.getAttribute('aria-controls'));
+        var clickOutside = !(toggle.contains(event.target) || contextualMenu.contains(event.target));
+
+        if (clickOutside) {
+          toggleMenu(toggle, false);
+        }
+      }
+    });
+
+    // Add handler for closing menus using ESC key.
+    document.addEventListener('keydown', function (e) {
+      e = e || window.event;
+
+      if (e.keyCode === 27) {
+        for (var i = 0, l = toggles.length; i < l; i++) {
+          toggleMenu(toggles[i], false);
+        }
+      }
+    });
+  }
+
+  setupAllContextualMenus('.p-contextual-menu__toggle');

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -8,6 +8,7 @@
     <meta name="description" content="{% block description %}Anbox Cloud is the mobile cloud computing platform delivered by Canonical. Run Android in the cloud, at high scale and on any type of hardware. Canonical partners with cloud providers and computing hardware manufacturers to accelerate your time to market and provide long term commercial support.{% endblock %}">
     <script src="https://assets.ubuntu.com/v1/4176b39e-serialize.js" defer></script>
     <script src="/static/js/formValidation.js" defer></script>
+    <script src="/static/js/contextualMenu.js" defer></script>
     <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
     <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
     <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -559,7 +559,7 @@
                       </button>
                   <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" >
                     <span class="p-contextual-menu__group">
-                      <a href="https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4" class="p-contextual-menu__link">on x86</a>
+                      <a href="https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4" class="p-contextual-menu__link p-link--external">on x86</a>
                       <a href="https://aws.amazon.com/marketplace/pp/prodview-aqmdt52vqs5qk" class="p-contextual-menu__link">on Arm</a>
                     </span>
                   </span>

--- a/templates/index.html
+++ b/templates/index.html
@@ -560,7 +560,7 @@
                   <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" >
                     <span class="p-contextual-menu__group">
                       <a href="https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4" class="p-contextual-menu__link p-link--external">on x86</a>
-                      <a href="https://aws.amazon.com/marketplace/pp/prodview-aqmdt52vqs5qk" class="p-contextual-menu__link">on Arm</a>
+                      <a href="https://aws.amazon.com/marketplace/pp/prodview-aqmdt52vqs5qk" class="p-contextual-menu__link p-link--external">on Arm</a>
                     </span>
                   </span>
                 </span>

--- a/templates/index.html
+++ b/templates/index.html
@@ -495,6 +495,7 @@
           <thead>
             <tr>
               <th></th>
+              <th class="u-align--center">Appliance</th>
               <th class="u-align--center">Custom deployment</th>
               <th class="u-align--center">Fully managed deployment</th>
             </tr>
@@ -502,46 +503,68 @@
           <tbody>
             <tr>
               <th>Streaming capabilities</th>
+              <td aria-label="Appliance" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Custom deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Fully managed deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
             </tr>
             <tr>
               <th>Dashboard</th>
+              <td aria-label="Appliance" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Custom deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Fully managed deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
             </tr>
             <tr>
               <th>Android API version</th>
+              <td aria-label="Appliance" class="table-cell">10, 11</td>
               <td aria-label="Custom deployment" class="table-cell">10, 11</td>
               <td aria-label="Fully managed deployment" class="table-cell">10, 11</td>
             </tr>
             <tr>
               <th>Long term security updates</th>
+              <td aria-label="Appliance" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Custom deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Fully managed deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
             </tr>
             <tr>
               <th>Community support</th>
+              <td aria-label="Appliance" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Custom deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Fully managed deployment" class="table-cell "><i class="p-icon--success">Yes</i></td>
             </tr>
             <tr>
               <th>Vendor support</th>
+              <td aria-label="Appliance" class="table-cell"><span aria-label="No">&ndash;</span></td>
               <td aria-label="Custom deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Fully managed deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
             </tr>
             <tr>
               <th>Monitoring</th>
+              <td aria-label="Appliance" class="table-cell"><span aria-label="No">&ndash;</span></td>
               <td aria-label="Custom deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
               <td aria-label="Fully managed deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
             </tr>
             <tr>
               <th>SLAs</th>
+              <td aria-label="Appliance" class="table-cell"><span aria-label="No">&ndash;</span></td>
               <td aria-label="Custom deployment" class="table-cell"><span aria-label="No">&ndash;</span></td>
               <td aria-label="Fully managed deployment" class="table-cell"><i class="p-icon--success">Yes</i></td>
             </tr>
             <tr class="u-hide--small">
               <th></th>
+              <td aria-label="Appliance" class="table-cell" style="overflow: unset;">
+                <span class="p-contextual-menu--left" style="z-index: 10;">
+                  <button class="p-button--neutral p-contextual-menu__toggle has-icon" aria-controls="menu-3"
+                          aria-expanded="false" aria-haspopup="true">
+                          <span>Deploy on AWS</span><i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
+                      </button>
+                  <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" >
+                    <span class="p-contextual-menu__group">
+                      <a href="https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4" class="p-contextual-menu__link">on x86</a>
+                      <a href="https://aws.amazon.com/marketplace/pp/prodview-aqmdt52vqs5qk" class="p-contextual-menu__link">on Arm</a>
+                    </span>
+                  </span>
+                </span>
+              </td>
               <td aria-label="Custom deployment" class="table-cell"><a href="/contact-us" class="p-button--neutral">Contact us</a></td>
               <td aria-label="Fully managed deployment" class="table-cell"><a href="/contact-us" class="p-button--neutral">Contact us</a></td>
             </tr>


### PR DESCRIPTION
## Done

Add Anbox Cloud Appliance to the variant table with deploy button linking to AWS marketplace

I had to use a contextual menu as we have two different marketplace listings we need to link to: one for Arm and one for x86. Using two buttons felt wrong. Open for suggestions on how to do better. JS code is taken from the vanilla documentation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
DEMO HERE: https://anbox-cloud-io-186.demos.haus/


## Issue / Card

n/a

## Screenshots

![website-deploy-appliance](https://user-images.githubusercontent.com/433752/127519582-b07b6cbd-f229-4d19-ad80-3c1661c31efa.png)

