### PR TITLE
Add sitemaps endpoints

### DIFF
--- a/templates/sitemap/sitemap-index.xml
+++ b/templates/sitemap/sitemap-index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://anbox-cloud.io/sitemap-links.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://anbox-cloud.io/docs/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/templates/sitemap/sitemap-links.xml
+++ b/templates/sitemap/sitemap-links.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://anbox-cloud.io/</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://anbox-cloud.io/contact-us</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://anbox-cloud.io/terms</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://anbox-cloud.io/privacy</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://anbox-cloud.io/virtual</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://anbox-cloud.io/enterprise</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://anbox-cloud.io/gaming</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+
+  <url>
+    <loc>https://anbox-cloud.io/testing</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+</urlset>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -151,6 +151,24 @@ def testing():
     return flask.render_template("testing/index.html")
 
 
+@app.route("/sitemap.xml")
+def sitemap_index():
+    xml_sitemap = flask.render_template("sitemap/sitemap-index.xml")
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+
+    return response
+
+
+@app.route("/sitemap-links.xml")
+def sitemap_links():
+    xml_sitemap = flask.render_template("sitemap/sitemap-links.xml")
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+
+    return response
+
+
 @open_id.after_login
 def after_login(resp):
     """


### PR DESCRIPTION
## Done

- add Sitemaps to anbox-cloud :tada: 

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8043/sitemap.xml
- Remove the anbox-cloud URL and replace with the demo/localhost link
- Make sure they work


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
