### PR TITLE
Updates yarn run to  use --production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 FROM node:12 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
-RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install --production
 
 # Build stage: Run "yarn run build-js"
 # ===

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "@canonical/cookie-policy": "3.3.0",
     "@canonical/global-nav": "2.5.0",
     "postcss": "8.2.10",
-    "vanilla-framework": "2.33.1"
+    "sass": "1.27.0",
+    "vanilla-framework": "2.33.1",
+    "autoprefixer": "10.2.3"
   },
   "devDependencies": {
-    "autoprefixer": "10.2.3",
     "concurrently": "5.3.0",
     "postcss-cli": "8.3.1",
-    "sass": "1.27.0",
     "sass-lint": "1.13.1",
     "watch-cli": "0.2.3"
   }


### PR DESCRIPTION
## Done

- Updates docker to run yarn with --production tag.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
