### PR TITLE
Replace muted headings with h4

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -208,7 +208,7 @@
                   attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
                 ) | safe
               }}
-              <p class="p-heading-icon__title p-heading--4" style="line-height: 1.5rem; color: #fff">Whitepaper</p>
+              <p class="p-heading--4">Whitepaper</p>
             </div>
           </div>
           <div class="p-matrix__desc">
@@ -230,7 +230,7 @@
                 attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <p class="p-heading-icon__title p-heading--4" style="line-height: 1.5rem; color: #fff">Whitepaper</p>
+            <p class="p-heading--4">Whitepaper</p>
           </div>
           <div class="p-matrix__desc">
             <a class="p-link--inverted p-link--external" href="https://ubuntu.com/engage/anbox-cloud-gaming-whitepaper">Cloud gaming for Android</a>
@@ -251,7 +251,7 @@
                 attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <p class="p-heading-icon__title p-heading--4" style="line-height: 1.5rem; color: #fff">Whitepaper</p>
+            <p class="p-heading--4">Whitepaper</p>
           </div>
           <div class="p-matrix__desc">
             <a class="p-link--inverted p-link--external" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Android_cloud_Arm_native_servers.pdf">Android in the cloud on ARM native servers</a>
@@ -272,7 +272,7 @@
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <p class="p-heading-icon__title p-heading--4" style="line-height: 1.5rem; color: #fff">Blog</p>
+            <p class="p-heading--4">Blog</p>
           </div>
           <div class="p-matrix__desc">
             <a class="p-link--inverted p-link--external" href="https://ubuntu.com/blog/implementing-an-android-based-cloud-game-streaming-service-with-anbox-cloud">Implementing an Android&trade; based cloud game streaming service with Anbox Cloud</a>
@@ -293,7 +293,7 @@
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <p class="p-heading-icon__title p-heading--4" style="line-height: 1.5rem; color: #fff">Webinar</p>
+            <p class="p-heading--4">Webinar</p>
           </div>
           <div class="p-matrix__desc">
             <a class="p-link--inverted p-link--external" href="https://ubuntu.com/engage/anbox-cloud-webinar">Introduction to Anbox Cloud</a>
@@ -314,7 +314,7 @@
               attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
               ) | safe
             }}
-            <p class="p-heading-icon__title p-heading--4" style="line-height: 1.5rem; color: #fff">Blog</p>
+            <p class="p-heading--4">Blog</p>
           </div>
           <div class="p-matrix__desc">
             <a class="p-link--inverted p-link--external" href="https://ubuntu.com/blog/anbox-cloud-disrupts-mobile-user-experience">Anbox Cloud disrupts mobile UX</a>


### PR DESCRIPTION
## Done

- Replace Muted heading with `<h4>` as per design advice 

## QA

- View page at: 
- Check "Learn more about Android in the cloud" section has correct headings as per [design](https://github.com/canonical-web-and-design/vanilla-framework/pull/3935#issuecomment-905288532) suggestion

## Issue / Card

Fixes #194 

## Screenshots

![Screenshot 2021-09-02 at 16 12 48](https://user-images.githubusercontent.com/58959073/131869727-bcf5ed6f-ef38-446f-a26c-b9c73cf13e0c.png)

