### PR TITLE
Add and initial run of inclusive-naming action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -93,3 +93,16 @@ jobs:
           coverage run  --source=. -m unittest discover tests
           bash <(curl -s https://codecov.io/bash) -cF python
 
+  inclusive-naming-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: woke
+        uses: canonical-web-and-design/inclusive-naming@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+          fail-on-error: true

--- a/templates/index.html
+++ b/templates/index.html
@@ -112,7 +112,7 @@
       <h3>Virtualise phones and tablets</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Run virtual Android instances in the cloud</li>
-        <li class="p-list__item is-ticked">Client interface available as built-in or web application</li>
+        <li class="p-list__item is-ticked">Client interface available as native or web application</li>
         <li class="p-list__item is-ticked">Full sensor integration</li>
         <li class="p-list__item is-ticked">Android communication stack enabled</li>
       </ul>

--- a/templates/index.html
+++ b/templates/index.html
@@ -112,7 +112,7 @@
       <h3>Virtualise phones and tablets</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Run virtual Android instances in the cloud</li>
-        <li class="p-list__item is-ticked">Client interface available as native or web application</li>
+        <li class="p-list__item is-ticked">Client interface available as built-in or web application</li>
         <li class="p-list__item is-ticked">Full sensor integration</li>
         <li class="p-list__item is-ticked">Android communication stack enabled</li>
       </ul>
@@ -254,7 +254,7 @@
             <p class="p-heading--4">Whitepaper</p>
           </div>
           <div class="p-matrix__desc">
-            <a class="p-link--inverted p-link--external" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Android_cloud_Arm_native_servers.pdf">Android in the cloud on ARM native servers</a>
+            <a class="p-link--inverted p-link--external" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Android_cloud_Arm_native_servers.pdf">Android in the cloud on ARM core servers</a>
           </div>
         </div>
       </li>


### PR DESCRIPTION
## Done

- Adds the inclusive-naming github action
- Runs it once to clean out past non-inclusive names
- NOTE: Doesn't edit links.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the CI/CD action works
- Check that the language change make lexical sense and don't break anything


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4445
