### PR TITLE
ignore failing link that requires login

### DIFF
--- a/scripts/linkcheckerrc
+++ b/scripts/linkcheckerrc
@@ -12,6 +12,7 @@ ignore=
   /w_
   /h_
   https://assets\.ubuntu\.com
+  https://bugs.launchpad.net/indore-extern/+filebug
 
 [output]
 status=0


### PR DESCRIPTION
Signed-off-by: Ruth Fuchss <ruth.fuchss@canonical.com>