### PR TITLE
Use original Flask-OpenID instead of Flask-OpenID-Stateless

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,10 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install dotrun
-        run: |
-          sudo snap install dotrun
-          sudo chown root:root /
+      - name: Install Dotrun
+        uses: canonical/install-dotrun@main
 
       - name: Install dependencies
         run: dotrun install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==0.9.2
 canonicalwebteam.discourse==4.0.4
-Flask-OpenID-Stateless==1.2.6
+Flask-OpenID==1.3.0
 requests==2.25.1
 responses==0.12.1
 pymacaroons==0.13.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -34,7 +34,9 @@ app = FlaskBase(
 
 app.secret_key = os.environ["SECRET_KEY"]
 open_id = OpenID(
-    stateless=True, safe_roots=[], extension_responses=[MacaroonResponse]
+    store_factory=lambda: None,
+    safe_roots=[],
+    extension_responses=[MacaroonResponse],
 )
 
 # Discourse docs


### PR DESCRIPTION
## Done

- This is a copy of this PR for snapcraft.io: https://github.com/canonical-web-and-design/snapcraft.io/pull/3740
- Stop using our own fork FlaskOpenID-Stateless to use the original module.

## QA

- Check the authentication is working as usual.
