### PR TITLE
Add customer logos section

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -418,7 +418,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <div class="p-logo-section">
-      <h2 class="u-sv3">Clouds service providers</h2>
+      <h2 class="u-sv3">Cloud service providers</h2>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{ image (
@@ -473,6 +473,48 @@
             alt="Oracle cloud",
             width="350",
             height="165",
+            hi_def=True,
+            attrs={"class":"p-logo-section__logo"},
+            loading="lazy"
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
+
+    <div class="p-logo-section">
+      <h2 class="u-sv3">A selection of customers</h2>
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item"> 
+          {{ image (
+            url="https://assets.ubuntu.com/v1/be72de6b-Vodafone-Logo.png",
+            alt="",
+            width="3840",
+            height="2160",
+            hi_def=True,
+            attrs={"class":"p-logo-section__logo"},
+            loading="lazy"
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item"> 
+          {{ image (
+            url="https://assets.ubuntu.com/v1/136b25bc-umony.png",
+            alt="",
+            width="278",
+            height="80",
+            hi_def=True,
+            attrs={"class":"p-logo-section__logo"},
+            loading="lazy"
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item"> 
+          {{ image (
+            url="https://assets.ubuntu.com/v1/f7cac7bd-clario.svg",
+            alt="",
+            width="189",
+            height="26",
             hi_def=True,
             attrs={"class":"p-logo-section__logo"},
             loading="lazy"

--- a/templates/index.html
+++ b/templates/index.html
@@ -79,7 +79,7 @@
       </ul>
       <a href="/gaming">Learn more about game streaming&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
+    <div class="col-6 u-hide--small u-hide--medium u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/da83f401-4+-+Register+to+the+snap+store+and+distribute+your+application+to+RasPi+users+everywhere.svg",
         alt="",
@@ -97,7 +97,7 @@
   </div>
 
   <div class="row u-vertically-center">
-    <div class="col-6 u-hide--small u-align--center">
+    <div class="col-6 u-hide--small u-hide--medium u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/d2387483-telecommunications-grey.svg",
         alt="",
@@ -135,7 +135,7 @@
       </ul>
       <a href="/enterprise">Learn more about secure apps&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-6 u-hide--small u-align--center">
+    <div class="col-6 u-hide--small i-hide--medium u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/9c80823b-confinement.svg",
         alt="",
@@ -153,7 +153,7 @@
   </div>
 
   <div class="row u-vertically-center">
-    <div class="col-6 u-align--center u-hide--small">
+    <div class="col-6 u-align--center u-hide--small u-hide--medium">
       {{ image (
         url="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg",
         alt="",

--- a/templates/index.html
+++ b/templates/index.html
@@ -135,7 +135,7 @@
       </ul>
       <a href="/enterprise">Learn more about secure apps&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-6 u-hide--small i-hide--medium u-align--center">
+    <div class="col-6 u-hide--small u-hide--medium u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/9c80823b-confinement.svg",
         alt="",


### PR DESCRIPTION
## Done

Added customer logo section according to [copy doc](https://docs.google.com/document/d/1SfpOBeDJUZj2ZYq4V8lHOUbQF9Yzo7mp5NajJDVwFMI/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- See that the logo sections look good and match the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4830


## Screenshot
![Screenshot from 2022-03-01 15-49-13](https://user-images.githubusercontent.com/2376968/156201391-ca9f52f3-ac84-461e-a47d-0f4652e25842.png)

