### PR TITLE
Use expandable nav for docs

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -2,20 +2,26 @@
 
 {% block title %}{{ document.title }} | Anbox documentation{% endblock %}
 
-{% macro create_navigation(nav_items) %}
-  <ul>
+{% macro create_navigation(nav_items, expandable=False) %}
+  <ul class="p-side-navigation__list">
     {% for element in nav_items %}
-    <li>
+    <li class="p-side-navigation__item">
       {% if element.navlink_href %}
-        <a href="{{ element.navlink_href }}"
-          {% if request.path == element.navlink_href %}aria-current="page"{% endif %}
-        >{{ element.navlink_text }}</a>
+      <a class="p-side-navigation__link" href="{{ element.navlink_href }}"
+        {% if element.is_active %}aria-current="page"{% endif %}
+      >{{ element.navlink_text }}</a>
       {% else %}
-        <strong>{{ element.navlink_text }}</strong>
+        <span class="p-side-navigation__text">{{ element.navlink_text }}</span>
       {% endif %}
 
-      {% if element.children %}
-        {{ create_navigation(element.children) }}
+      {% if expandable %}
+        {% if element.children and (element.is_active or element.has_active_child) %}
+          {{ create_navigation(element.children, True) }}
+        {% endif %}
+      {% else %}
+        {% if element.children %}
+          {{ create_navigation(element.children, False) }}
+        {% endif %}
       {% endif %}
     </li>
     {% endfor %}
@@ -47,7 +53,7 @@
         <select>
         {% endif %}
 
-        <nav data-js="navigation" class="p-side-navigation--raw-html" id="{{ navigation['path'] or 'default' }}">
+        <nav data-js="navigation" class="p-side-navigation" id="{{ navigation['path'] or 'default' }}">
           <a href="#{{ navigation['path'] or 'default' }}" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="{{ navigation['path'] or 'default' }}">
             Toggle side navigation
           </a>
@@ -59,21 +65,23 @@
               </a>
             </div>
             {% for nav_group in navigation.nav_items %}
-              {% if nav_group.navlink_text %}
-                {% if nav_group.navlink_href %}
-                <h3>
-                  <a href="{{ nav_group.navlink_href }}" {% if request.path == nav_group.navlink_href %}aria-current="page"{% endif %}>
-                    {{ nav_group.navlink_text }}
-                  </a>
-                </h3>
-                {% else %}
-                  <h3>{{ nav_group.navlink_text }}</h3>
-                {% endif %}
+            {% if nav_group.navlink_text %}
+              {% if nav_group.navlink_href %}
+              <h3 class="p-side-navigation__heading--linked">
+                <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+                  {{ nav_group.navlink_text }}
+                </a>
+              </h3>
+              {% else %}
+                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
               {% endif %}
-              {% if not nav_group.hidden %}
-              {{ create_navigation(nav_group.children) }}
-              {% endif %}
-            {% endfor %}
+            {% endif %}
+            {#
+              Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
+              Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
+            #}
+            {{ create_navigation(nav_group.children, expandable=True) }}
+          {% endfor %}
           </div>
         </nav>
       </aside>


### PR DESCRIPTION
## Done

Updates the docs template to use expandable side navigation, as described in [Creating Discourse based documentation pages](https://discourse.canonical.com/t/creating-discourse-based-documentation-pages/159)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to Anbox docs: https://anbox-cloud-io-247.demos.haus/docs
- Make sure all nested levels are collapsed by default
- Navigate to page that has child pages - https://anbox-cloud-io-247.demos.haus/docs/howto/install/landing
- Make sure child pages expand as expected
- QA side navigation on smaller screens, make sure the rest of documentation page template also works as expected


## Screenshots

<img width="313" alt="image" src="https://user-images.githubusercontent.com/83575/173588255-ad9494c3-cb96-49ac-8b37-98869fa025f2.png">
